### PR TITLE
feat: add underline on card title

### DIFF
--- a/src/app/tile/tile.component.html
+++ b/src/app/tile/tile.component.html
@@ -2,10 +2,14 @@
   class="card"
   [routerLink]="['/', 'details', nugget.id]"
   appRandomBackgroundColor
+  (mouseenter)="enter()"
+  (mouseleave)="leave()"
+  (focus)="enter()"
+  (focusout)="leave()"
 >
   <div class="inner-card">
     <div class="title">
-      <h1>
+      <h1 [class.underlined]="isMouseHover">
         <mat-icon
           aria-hidden="false"
           aria-label="Example home icon"

--- a/src/app/tile/tile.component.scss
+++ b/src/app/tile/tile.component.scss
@@ -87,3 +87,7 @@ a:active {
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+.underlined {
+  text-decoration: underline;
+}

--- a/src/app/tile/tile.component.ts
+++ b/src/app/tile/tile.component.ts
@@ -25,4 +25,14 @@ export class TileComponent {
 	public readonly IconConverter = IconConverter
 	@Input({required: true})
 		nugget!: WebNugget
+
+	public isMouseHover = false
+
+	public enter(): void {
+		this.isMouseHover = true
+	}
+
+	public leave(): void {
+		this.isMouseHover = false
+	}
 }


### PR DESCRIPTION
Couldn't have it animated because the cards are already heavily using CSS which colide with the animated underline title.

close #10